### PR TITLE
Explicitly include docker service in license check

### DIFF
--- a/license-checks.yaml
+++ b/license-checks.yaml
@@ -1,6 +1,9 @@
+variables:
+ - DOCKER_VERSION: 24.0.16-dind 
+
 license_scanning:
   tags:
-    - low-load
+    - small-runner
   stage: test
   variables:
     TRIVY_NO_PROGRESS: "true"
@@ -9,6 +12,9 @@ license_scanning:
     FILENAME: "gl-codeclimate-$CI_JOB_NAME_SLUG.json"
     SEVERITY: "HIGH,CRITICAL,UNKNOWN"
     SCANNERS: "license"
+  services:
+    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
+      alias: docker
   before_script:
     - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi
     - export TRIVY_VERSION=$(wget -qO - "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')

--- a/license-checks.yaml
+++ b/license-checks.yaml
@@ -1,5 +1,5 @@
 variables:
- - DOCKER_VERSION: 24.0.16-dind 
+ - DOCKER_VERSION: 24.0.16
 
 license_scanning:
   tags:
@@ -13,7 +13,7 @@ license_scanning:
     SEVERITY: "HIGH,CRITICAL,UNKNOWN"
     SCANNERS: "license"
   services:
-    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
+    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind 
       alias: docker
   before_script:
     - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi


### PR DESCRIPTION
- Define a DOCKER_VERSION variable that will be overridden in project's main gitlab-ci.yaml
- Explicitly include the service definition for docker in case project doesn't usually use docker