### PR TITLE
feat: run trivy as image instead of downloading manually

### DIFF
--- a/license-checks.yaml
+++ b/license-checks.yaml
@@ -24,6 +24,7 @@ license_scanning:
     - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
       alias: docker
   before_script:
+    - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi
     - touch $FILENAME
     - until docker info; do sleep 1; done # Mitigate GitLab-Runner not setting up DinD in time, see: https://gitlab.com/gitlab-org/gitlab/-/issues/354744
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY

--- a/license-checks.yaml
+++ b/license-checks.yaml
@@ -2,7 +2,9 @@ variables:
  - DOCKER_VERSION: 24.0.16
 
 license_scanning:
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
+  image: 
+    name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy:0.47.0
+    entrypoint: [""]
   tags:
     - small-runner
   stage: test
@@ -10,6 +12,9 @@ license_scanning:
     TRIVY_NO_PROGRESS: "true"
     TRIVY_CACHE_DIR: ".trivycache/"
     TRIVY_YAML: ""
+    TRIVY_USERNAME: "$CI_REGISTRY_USER"
+    TRIVY_PASSWORD: "$CI_REGISTRY_PASSWORD"
+    TRIVY_AUTH_URL: "$CI_REGISTRY"
     COMBINED_TRIVY_YAML: "${TRIVY_CACHE_DIR}trivy-combined.yaml"
     FILENAME: "gl-codeclimate-$CI_JOB_NAME_SLUG.json"
     SEVERITY: "HIGH,CRITICAL,UNKNOWN"
@@ -19,21 +24,15 @@ license_scanning:
     - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
       alias: docker
   before_script:
-    - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi
-    - export TRIVY_VERSION=$(wget -qO - "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-    - echo $TRIVY_VERSION
-    - if [ ! -e ${TRIVY_CACHE_DIR}trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz ]; then wget --no-verbose https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -O ${TRIVY_CACHE_DIR}trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz; fi
-    - tar -zxvf ${TRIVY_CACHE_DIR}trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -C .
-    - if [ ! -e ${TRIVY_CACHE_DIR}license-checks.tpl ]; then  wget --no-verbose https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/license-checks.tpl -O ${TRIVY_CACHE_DIR}license-checks.tpl; fi
-    - wget --no-verbose https://raw.githubusercontent.com/ambient-innovation/gitlab-trivy-license-checks/main/trivy.yaml -O ${TRIVY_CACHE_DIR}trivy.yaml
+    - touch $FILENAME
     - until docker info; do sleep 1; done # Mitigate GitLab-Runner not setting up DinD in time, see: https://gitlab.com/gitlab-org/gitlab/-/issues/354744
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - apk update && apk add yq
     - if [ -z "$TRIVY_YAML" ]; then echo "using default trivy.yaml"; cat ${TRIVY_CACHE_DIR}trivy.yaml > ${COMBINED_TRIVY_YAML}; else echo "combining ${TRIVY_CACHE_DIR}triv.yaml with ${TRIVY_YAML}"; yq eval-all '. as $item ireduce ({}; . *d+ $item )' ${TRIVY_CACHE_DIR}trivy.yaml ${TRIVY_YAML} > ${COMBINED_TRIVY_YAML}; fi
   allow_failure: true
   script:
-    - ./trivy image --config ${COMBINED_TRIVY_YAML} --exit-code 0 --severity $SEVERITY --scanners $SCANNERS --format table $IMAGE
-    - ./trivy image --config ${COMBINED_TRIVY_YAML} --exit-code ${EXIT_CODE_ON_FINDINGS} --severity $SEVERITY --scanners $SCANNERS --format template --template "@${TRIVY_CACHE_DIR}license-checks.tpl" -o $FILENAME $IMAGE >/dev/null 2>&1
+    - trivy image --config ${COMBINED_TRIVY_YAML} --exit-code 0 --severity $SEVERITY --scanners $SCANNERS --format table $IMAGE
+    - trivy image --config ${COMBINED_TRIVY_YAML} --exit-code ${EXIT_CODE_ON_FINDINGS} --severity $SEVERITY --scanners $SCANNERS --format template --template "@${TRIVY_CACHE_DIR}license-checks.tpl" -o $FILENAME $IMAGE >/dev/null 2>&1
   cache:
     paths:
       - $TRIVY_CACHE_DIR

--- a/license-checks.yaml
+++ b/license-checks.yaml
@@ -1,6 +1,3 @@
-variables:
- - DOCKER_VERSION: 24.0.16
-
 license_scanning:
   image: 
     name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy
@@ -20,14 +17,9 @@ license_scanning:
     COMBINED_TRIVY_YAML: "${TRIVY_CACHE_DIR}trivy-combined.yaml"
     FILENAME: "gl-codeclimate-$CI_JOB_NAME_SLUG.json"
     EXIT_CODE_ON_FINDINGS: 0
-  services:
-    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
-      alias: docker
   before_script:
     - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi
     - touch $FILENAME
-    - until docker info; do sleep 1; done # Mitigate GitLab-Runner not setting up DinD in time, see: https://gitlab.com/gitlab-org/gitlab/-/issues/354744
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - apk update && apk add yq
     - if [ -z "$TRIVY_YAML" ]; then echo "using default trivy.yaml"; cat ${TRIVY_CACHE_DIR}trivy.yaml > ${COMBINED_TRIVY_YAML}; else echo "combining ${TRIVY_CACHE_DIR}triv.yaml with ${TRIVY_YAML}"; yq eval-all '. as $item ireduce ({}; . *d+ $item )' ${TRIVY_CACHE_DIR}trivy.yaml ${TRIVY_YAML} > ${COMBINED_TRIVY_YAML}; fi
   allow_failure: true

--- a/license-checks.yaml
+++ b/license-checks.yaml
@@ -3,7 +3,7 @@ variables:
 
 license_scanning:
   image: 
-    name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy:0.47.0
+    name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy
     entrypoint: [""]
   tags:
     - small-runner
@@ -15,10 +15,10 @@ license_scanning:
     TRIVY_USERNAME: "$CI_REGISTRY_USER"
     TRIVY_PASSWORD: "$CI_REGISTRY_PASSWORD"
     TRIVY_AUTH_URL: "$CI_REGISTRY"
+    TRIVY_SEVERITY: "HIGH,CRITICAL,UNKNOWN"
+    TRIVY_SCANNERS: "license"
     COMBINED_TRIVY_YAML: "${TRIVY_CACHE_DIR}trivy-combined.yaml"
     FILENAME: "gl-codeclimate-$CI_JOB_NAME_SLUG.json"
-    SEVERITY: "HIGH,CRITICAL,UNKNOWN"
-    SCANNERS: "license"
     EXIT_CODE_ON_FINDINGS: 0
   services:
     - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
@@ -32,8 +32,8 @@ license_scanning:
     - if [ -z "$TRIVY_YAML" ]; then echo "using default trivy.yaml"; cat ${TRIVY_CACHE_DIR}trivy.yaml > ${COMBINED_TRIVY_YAML}; else echo "combining ${TRIVY_CACHE_DIR}triv.yaml with ${TRIVY_YAML}"; yq eval-all '. as $item ireduce ({}; . *d+ $item )' ${TRIVY_CACHE_DIR}trivy.yaml ${TRIVY_YAML} > ${COMBINED_TRIVY_YAML}; fi
   allow_failure: true
   script:
-    - trivy image --config ${COMBINED_TRIVY_YAML} --exit-code 0 --severity $SEVERITY --scanners $SCANNERS --format table $IMAGE
-    - trivy image --config ${COMBINED_TRIVY_YAML} --exit-code ${EXIT_CODE_ON_FINDINGS} --severity $SEVERITY --scanners $SCANNERS --format template --template "@${TRIVY_CACHE_DIR}license-checks.tpl" -o $FILENAME $IMAGE >/dev/null 2>&1
+    - trivy image --config ${COMBINED_TRIVY_YAML} --exit-code 0 --format template --template "@${TRIVY_CACHE_DIR}license-checks.tpl" -o $FILENAME $IMAGE >/dev/null 2>&1
+    - trivy image --config ${COMBINED_TRIVY_YAML} --exit-code ${EXIT_CODE_ON_FINDINGS} --format table $IMAGE
   cache:
     paths:
       - $TRIVY_CACHE_DIR


### PR DESCRIPTION
Reduce complexity by using the official docker image as the CI job image instead of downloading by hand